### PR TITLE
Add `$Hash` param and enhance install test script

### DIFF
--- a/test/Install-Test.ps1
+++ b/test/Install-Test.ps1
@@ -2,7 +2,7 @@
 
 param(
     [String[]]
-    $Hash = "" # specify commit hash to test
+    $Hash # specify commit hash to test
 )
 
 $Files = $(git show $Hash --pretty="" --name-only) -Split "\n"

--- a/test/Install-Test.ps1
+++ b/test/Install-Test.ps1
@@ -1,6 +1,11 @@
 #Requires -Version 5
 
-$Files = $(git show --pretty="" --name-only) -Split "\n"
+param(
+    [String[]]
+    $Hash = "" # specify commit hash to test
+)
+
+$Files = $(git show $Hash --pretty="" --name-only) -Split "\n"
 $APPS_CHANGED = @()
 
 foreach ($_ in $Files) {
@@ -8,9 +13,9 @@ foreach ($_ in $Files) {
         $Name = $_ -Replace "bucket/" -Replace ".json"
         $APPS_CHANGED += $Name
     }
-
-    Write-Output "$APPS_CHANGED"
 }
+
+Write-Output "Apps changed: $APPS_CHANGED"
 
 # One by one, install app that have been changed as test.
 foreach ($APP in $APPS_CHANGED) {


### PR DESCRIPTION
- Add `$Hash` parameter to allow testing specific commit changes.
- Improve `$APPS_CHANGED` output messages and enhance install test script flexibility.