### PR TITLE
ci: skip mc-bedrock-server in install test

### DIFF
--- a/test/Install-Test.ps1
+++ b/test/Install-Test.ps1
@@ -11,6 +11,11 @@ $APPS_CHANGED = @()
 foreach ($_ in $FILES_CHANGED) {
     if ($_ -like "bucket*") {
         $Name = $_ -Replace "bucket/" -Replace ".json"
+        if ($Name -eq "mc-bedrock-server") {
+            # skip mc-bedrock-server, can't download by scoop default user-agent
+            Write-Host "Skip $Name" -ForegroundColor DarkYellow
+            continue
+        }
         $APPS_CHANGED += $Name
     }
 }


### PR DESCRIPTION
Skip installing `mc-bedrock-server` in the actions workflow as it cannot be downloaded using [scoop]'s default `user-agent`.
And the scoop can't customize the user-agent for downloading assets now.

[scoop]: https://github.com/ScoopInstaller/Scoop